### PR TITLE
Feat/export history

### DIFF
--- a/backend/script.js
+++ b/backend/script.js
@@ -69,3 +69,29 @@ function updateHistory() {
         )
         .join("");
 }
+
+function exportHistory() {
+    if (history.length === 0) {
+        alert("No history to export.");
+        return;
+    }
+
+    const header = "Test Number,Download (Mbps),Upload (Mbps),Ping (ms),Jitter (ms)";
+    const csvRows = history.map((result, index) => 
+        `${index + 1},${result.download},${result.upload},${result.ping},${result.jitter}`
+    );
+    const csvString = [header, ...csvRows].join("\n");
+
+    const blob = new Blob([csvString], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "speedtest_history.csv";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+}
+
+document.getElementById("export-btn").addEventListener("click", exportHistory);

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,4 +1,4 @@
-/* Global Styles */ 
+/* Global Styles */
 body {
     font-family: "Poppins", sans-serif;
     background: linear-gradient(135deg, #0f172a, #1e293b);
@@ -108,24 +108,43 @@ h2 {
     display: none; /* Hidden by default */
 }
 
-/* Start Button */
-button {
-    background: linear-gradient(135deg, #00eaff, #008cff);
+/* Common Button Styles */
+.btn-base {
     border: none;
     padding: 12px 20px;
     font-size: 18px;
     color: #000;
     border-radius: 10px;
     cursor: pointer;
-    margin-top: 15px;
     transition: 0.3s;
-    box-shadow: 0 0 10px rgba(0, 255, 255, 0.5);
 }
 
-button:hover {
+.btn-base:hover {
+    transform: scale(1.05);
+}
+
+/* Start Test Button Specific Styles */
+#start-btn {
+    background: linear-gradient(135deg, #00eaff, #008cff);
+    box-shadow: 0 0 10px rgba(0, 255, 255, 0.5);
+    margin-top: 15px;
+}
+
+#start-btn:hover {
     background: linear-gradient(135deg, #00ccff, #006aff);
     box-shadow: 0 0 15px rgba(0, 255, 255, 0.8);
-    transform: scale(1.05);
+}
+
+/* Export History Button Specific Styles */
+#export-btn {
+    background: linear-gradient(135deg, #00e096, #00b377);
+    box-shadow: 0 0 10px rgba(0, 224, 150, 0.5);
+    margin-top: 10px;
+}
+
+#export-btn:hover {
+    background: linear-gradient(135deg, #00cc88, #009966);
+    box-shadow: 0 0 15px rgba(0, 204, 136, 0.8);
 }
 
 /* History Section */
@@ -149,24 +168,4 @@ button:hover {
     font-size: 14px;
     margin-bottom: 5px;
     color: #ccc;
-}
-
-/* Export Button */
-#export-btn {
-    background: linear-gradient(135deg, #00e096, #00b377);
-    border: none;
-    padding: 12px 20px;
-    font-size: 18px;
-    color: #000;
-    border-radius: 10px;
-    cursor: pointer;
-    margin-top: 10px;
-    transition: 0.3s;
-    box-shadow: 0 0 10px rgba(0, 224, 150, 0.5);
-}
-
-#export-btn:hover {
-    background: linear-gradient(135deg, #00cc88, #009966);
-    box-shadow: 0 0 15px rgba(0, 204, 136, 0.8);
-    transform: scale(1.05);
 }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -150,3 +150,23 @@ button:hover {
     margin-bottom: 5px;
     color: #ccc;
 }
+
+/* Export Button */
+#export-btn {
+    background: linear-gradient(135deg, #00e096, #00b377);
+    border: none;
+    padding: 12px 20px;
+    font-size: 18px;
+    color: #000;
+    border-radius: 10px;
+    cursor: pointer;
+    margin-top: 10px;
+    transition: 0.3s;
+    box-shadow: 0 0 10px rgba(0, 224, 150, 0.5);
+}
+
+#export-btn:hover {
+    background: linear-gradient(135deg, #00cc88, #009966);
+    box-shadow: 0 0 15px rgba(0, 204, 136, 0.8);
+    transform: scale(1.05);
+}

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
                 <h3>Test History</h3>
                 <ul id="history-list"></ul>
             </div>
+            <button id="export-btn">Export History</button>
         </div>
     </div>
     <audio id="complete-sound" src="complete.mp3"></audio>

--- a/index.html
+++ b/index.html
@@ -24,12 +24,12 @@
                 <p>Download: <span id="download">--</span> Mbps</p>
                 <p>Upload: <span id="upload">--</span> Mbps</p>
             </div>
-            <button id="start-btn">Start Test</button>
+            <button id="start-btn" class="btn-base">Start Test</button>
             <div class="history">
                 <h3>Test History</h3>
                 <ul id="history-list"></ul>
             </div>
-            <button id="export-btn">Export History</button>
+            <button id="export-btn" class="btn-base">Export History</button>
         </div>
     </div>
     <audio id="complete-sound" src="complete.mp3"></audio>


### PR DESCRIPTION
refactor: DRY button styling in CSS

I've refactored the CSS for buttons to reduce duplication and improve maintainability.

- I introduced a common class `.btn-base` in `frontend/style.css` to hold shared styling properties (padding, font, border-radius, etc.) for the "Start Test" and "Export History" buttons.
- I updated the `#start-btn` and `#export-btn` CSS rules to only contain their specific styles (background gradients, box-shadows, margins).
- I modified `index.html` to apply the `btn-base` class to both buttons.

This change does not alter the visual appearance of the buttons but makes the CSS more organized and easier to manage.